### PR TITLE
API key configuration and bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,8 @@ This Omeka plugin adds the ability to import Youtube videos into Omeka as items 
 
 If you use this plugin, please take a moment to submit feedback about your experience, so we can keep making Omeka better: [User Survey](https://docs.google.com/forms/d/1cn-0S5RRJEQirXS8dCmBA_t-q2hrIw7rtQ9n9i_3e0c/viewform?usp=send_form)
 
+### API Key
+The plugin requires a free [YouTube Data API V3 key](https://developers.google.com/youtube/v3), which can be configured at `/admin/plugins/config?name=YouTubeImport`.
+
 ### Configuring Display Dimensions
 The dimensions of the embedded youtube video display default to 640px by 360px. These dimensions can be set in the plugin configuration page, at `/admin/plugins/config?name=YouTubeImport`. Setting these values can fix display problems on some themes. Keep in mind that you should include units in your width and height entries (e.g. "640px" or "100%").

--- a/YouTubeImportPlugin.php
+++ b/YouTubeImportPlugin.php
@@ -40,7 +40,7 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
     /**
      * @var array Options for the plugin.
      */
-    protected $_options = array('youtube_width'=>640,'youtube_height'=>360);
+    protected $_options = array('youtube_width'=>640,'youtube_height'=>360, 'youtube_apikey'=>'AIzaSyDI8ApsA7MBIK4M1Ubs9k4-Rk7_KOeYJ5w');
 
 	
     public function hookInitialize(){
@@ -215,6 +215,8 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
             set_option('youtube_width',$_REQUEST['youtube_width']);
         if(isset($_REQUEST['youtube_height']))
             set_option('youtube_height',$_REQUEST['youtube_height']);
+        if(isset($_REQUEST['youtube_apikey']))
+            set_option('youtube_apikey', $_REQUEST['youtube_apikey']);
     }
 
     public function hookConfigForm(){

--- a/YouTubeImportPlugin.php
+++ b/YouTubeImportPlugin.php
@@ -71,7 +71,7 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
 	    
 	//if there is no "player" element installed, do nothing
         if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Player'))
-	    return $elementSets	
+	        return $elementSets;
 		
         // if there is no youtube player on this item, do nothing
         if(!metadata($item,array('Item Type Metadata','Player')))
@@ -107,14 +107,16 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
      *@return void
      */
     public function hookInstall(){
+        include_once(dirname(__FILE__).'/helpers/import.php');
         YoutubeImport_ImportHelper::CreateThumbnailElement;
         YoutubeImport_ImportHelper::CreatePlayerElement;
     }
 
     public function hookUpgrade($oldVersion,$newVersion){
+        include_once(dirname(__FILE__).'/helpers/import.php');
         if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Imported Thumbnail'))
             YoutubeImport_ImportHelper::CreateThumbnailElement;
-	if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Player'))
+	    if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Player'))
             YoutubeImport_ImportHelper::CreatePlayerElement;              
     }
 

--- a/forms/ImportForm.php
+++ b/forms/ImportForm.php
@@ -141,7 +141,7 @@ class Youtube_Form_Import extends Omeka_Form
 
         $client = new Google_Client();
         $client->setApplicationName("Omeka_Youtube_Import");
-        $client->setDeveloperKey(YoutubeImport_ImportHelper::$youtube_api_key);
+        $client->setDeveloperKey(YoutubeImport_ImportHelper::getApiKey());
   	
         try{
 	    $service = new Google_Service_YouTube($client);

--- a/forms/config_form.php
+++ b/forms/config_form.php
@@ -19,3 +19,14 @@
    <p class = "explanation">Enter the default height for display of videos imported from Youtube</p>
     </div>
 </div>
+
+<div class="field">
+    <div id="youtube-apikey-label" class="two columns alpha">
+        <label for="youtube_height"><?php echo __('YouTube API Key'); ?></label>
+    </div>
+    <div class="inputs five columns omega">
+   <?php echo get_view()->formText('youtube_apikey', get_option('youtube_apikey'), 
+        array()); ?>
+   <p class = "explanation">Enter a YouTube Data API V3 key, as YouTube rate limits the default key. See <a href="https://developers.google.com/youtube/v3">https://developers.google.com/youtube/v3</a>.</p>
+    </div>
+</div>

--- a/helpers/import.php
+++ b/helpers/import.php
@@ -15,9 +15,11 @@ class YoutubeImport_ImportHelper
 {
     
     /**
-     * @var string Youtube API key for this plugin
+     * @return $string Youtube API key for this plugin
      */
-    public static $youtube_api_key = 'AIzaSyDI8ApsA7MBIK4M1Ubs9k4-Rk7_KOeYJ5w';
+    public function getApiKey(){
+        return get_option('youtube_apikey');
+    }
     
     /**
      * @var string Google app name associated with this plugin


### PR DESCRIPTION
Incorporates #37 and #27, and adds basic config options so users can add their own YouTube Data API V3 key via the standard Omeka plugin config. The default key is both insecure and has a maxed out request limit but is left as a default.