### PR TITLE
Fix JS error on admin pages in Omeka 3.0

### DIFF
--- a/views/admin/javascripts/YoutubeImport.js
+++ b/views/admin/javascripts/YoutubeImport.js
@@ -1,4 +1,4 @@
-jQuery(window).load(function() {
+jQuery(document).ready(function() {
 
   jQuery("body.you-tube-import form").tooltip();
 


### PR DESCRIPTION
Change `jQuery(window).load` to `jQuery(document).ready` to remove this JS
error on admin pages in Omeka 3.0's admin theme:

```
Uncaught TypeError: e.indexOf is not a function
```